### PR TITLE
Updated README.md: Change origin to upstream on line 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is The Android repository for Zuri Chat project.
 - Fork the project.
 - Clone your own forked repository, run `git clone "https://github.com/[your_github_username]/zc_android.git"`
 
-Add remote upstream using the command `git remote add origin "https://github.com/zurichat/zc_android.git"`
+Add remote upstream using the command `git remote add upstream "https://github.com/zurichat/zc_android.git"`
 
 - run: `git fetch upstream` - You must fetch from develop before or after checkout<br/>
 - run: `git merge upstream/develop` - Merge updates from upstream<br/>


### PR DESCRIPTION
As a beginner in using GitHub, I find it difficult trying to set up the project after I forked it. But in the end, I found out that this might be the problem:

I replaced origin with **upstream** in the below command and it worked.

Add remote upstream using the command git remote add **origin** "https://github.com/zurichat/zc_android.git"

