### PR TITLE
feat: Implemented Message Notifications: For ChannelChat Activity an  DM Activity

### DIFF
--- a/app/src/main/java/com/tolstoy/zurichat/ui/activities/ChannelChatActivity.kt
+++ b/app/src/main/java/com/tolstoy/zurichat/ui/activities/ChannelChatActivity.kt
@@ -1,7 +1,13 @@
 package com.tolstoy.zurichat.ui.activities
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
+import android.graphics.BitmapFactory
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -11,6 +17,8 @@ import android.widget.ImageView
 import android.widget.PopupWindow
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.bumptech.glide.Glide
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.tolstoy.zurichat.R
@@ -24,12 +32,17 @@ class ChannelChatActivity : AppCompatActivity() {
     lateinit var imagePicker: ImagePicker
     private var mTopToolbar: Toolbar? = null
 
+    //For Message Notifications
+    private val CHANNEL_ID = "zuriChat_channels_id_01"
+    private val notificationId = 101
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_channel_chat)
 
         mTopToolbar = findViewById(R.id.my_toolbar)
         setSupportActionBar(mTopToolbar)
+
         // This setups application theme to value stored in sharedPref
         setUpApplicationTheme(this)
 
@@ -38,6 +51,14 @@ class ChannelChatActivity : AppCompatActivity() {
         val sendVoiceNote = findViewById<FloatingActionButton>(R.id.send_voice_btn)
         val sendMessage = findViewById<FloatingActionButton>(R.id.send_message_btn)
         var text: String? = null
+
+        //This makes a call to the message notifications function
+        createNotificationChannel()
+
+        //This sends a notification, that a message has been sent, as soon as the send button is clicked
+        sendMessage.setOnClickListener{
+            sendNotification()
+        }
 
         //Change Icon on editText Click
         val currentMessage = channelChatEdit.text.toString()
@@ -89,6 +110,45 @@ class ChannelChatActivity : AppCompatActivity() {
 
     }
 
+    //Function to start message notification for Oreo version devices and above
+    fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            val name = "ZuriChat Channels Message Notification"
+            val descriptionText = "You've got a new message on Channels - ZuriChat"
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+            }
+            val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    //Function to start message notification for older version devices
+    fun sendNotification() {
+        val intent = Intent(this, ChannelChatActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(this, 0, intent, 0)
+
+        val bitmap = BitmapFactory.decodeResource(applicationContext.resources, R.drawable.logo1)
+        val bitmapLargeIcon = BitmapFactory.decodeResource(applicationContext.resources, R.drawable.splash_logo)
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.logo1)
+            .setContentTitle("ZuriChat Channels Message Notification")
+            .setContentText("You've got a new message on Channels - ZuriChat")
+            .setLargeIcon(bitmapLargeIcon)
+//            .setStyle(NotificationCompat.BigTextStyle().bigText("You've got a new message on 4 Channels you belong to - ZuriChat"))
+            .setStyle(NotificationCompat.BigPictureStyle().bigPicture(bitmap))
+            .setContentIntent(pendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+        with(NotificationManagerCompat.from(this)){
+            notify(notificationId, builder.build())
+        }
+    }
+
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         val inflater: MenuInflater = menuInflater
         inflater.inflate(R.menu.channel_chat_menu, menu)
@@ -106,6 +166,4 @@ class ChannelChatActivity : AppCompatActivity() {
             else -> super.onOptionsItemSelected(item)
         }
     }
-
-
 }

--- a/app/src/main/java/com/tolstoy/zurichat/ui/activities/DMActivity.kt
+++ b/app/src/main/java/com/tolstoy/zurichat/ui/activities/DMActivity.kt
@@ -1,6 +1,13 @@
 package com.tolstoy.zurichat.ui.activities
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -13,6 +20,8 @@ import android.widget.PopupWindow
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -31,6 +40,11 @@ import java.util.*
 class DMActivity : AppCompatActivity() {
     lateinit var imagePicker: ImagePicker
     private val adapter by lazy { MessageAdapter(this, 0) }
+
+    //For Message Notifications
+    private val CHANNEL_ID = "zuriChat_dms_id_01"
+    private val notificationId = 102
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_dmactivity)
@@ -94,6 +108,9 @@ class DMActivity : AppCompatActivity() {
         //update chat screen
         update(demoDmMessages)
 
+        //This makes a call to the message notifications function
+        createNotificationChannel()
+
         //call the sendMessage function when button is clicked and pass message as argument
         sendMessage.setOnClickListener {
             val message = dmEditText.text.toString()
@@ -113,6 +130,9 @@ class DMActivity : AppCompatActivity() {
             demoDmMessages.add(dms)
             update(demoDmMessages)
             dmEditText.text.clear()
+
+            //This sends a notification, that a message has been sent, as soon as the send button is clicked
+            sendNotification()
         }
 
         //Launch Attachment popup
@@ -176,6 +196,45 @@ class DMActivity : AppCompatActivity() {
                     Toast.makeText(this, "Picture not taken", Toast.LENGTH_LONG).show()
                 }
             }
+        }
+    }
+
+    //Function to start message notification for Oreo version devices and above
+    fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            val name = "ZuriChat Message Notification"
+            val descriptionText = "You've got a new message from one of your contacts on ZuriChat"
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+            }
+            val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    //Function to start message notification for older version devices
+    fun sendNotification() {
+        val intent = Intent(this, DMActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(this, 0, intent, 0)
+
+        val bitmap = BitmapFactory.decodeResource(applicationContext.resources, R.drawable.logo1)
+        val bitmapLargeIcon = BitmapFactory.decodeResource(applicationContext.resources, R.drawable.splash_logo)
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.logo1)
+            .setContentTitle("ZuriChat Channels Message Notification")
+            .setContentText("You've got a new message on Channels - ZuriChat")
+            .setLargeIcon(bitmapLargeIcon)
+//            .setStyle(NotificationCompat.BigTextStyle().bigText("You've got a new message on 4 Channels you belong to - ZuriChat"))
+            .setStyle(NotificationCompat.BigPictureStyle().bigPicture(bitmap))
+            .setContentIntent(pendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+
+        with(NotificationManagerCompat.from(this)){
+            notify(notificationId, builder.build())
         }
     }
 }


### PR DESCRIPTION
Implemented notifications for new messages on channels and dms.
- As soon as a new message is sent, the app notifies the user.
- User can click on the notification, and it redirects the user to the Channels Activity or DM Activity as the case may be.


Play screen record below

https://user-images.githubusercontent.com/53825120/133948328-8a6aefc7-80dd-4da4-82df-77caca501b1e.mp4

Kindly see attached image

![ZuriChat Message Notifications Screenshoot](https://user-images.githubusercontent.com/53825120/133948560-11f2329f-09cb-4fc9-b039-09f9932def9a.jpg)

